### PR TITLE
fix: add type module to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "dist/VueMarkdown.d.ts",
   "author": "Patrick Kuen <p.kuen@cloudacy.com>",
   "license": "MIT",
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "https://github.com/cloudacy/vue-markdown-render.git"


### PR DESCRIPTION
Hi!
Building a site with vite-ssg failed with "SyntaxError: Cannot use import statement outside a module" on vue-markdown-render. Just setting `"type": "module"` in `package.json` seems to fix the problem.

Thanks for a useful package!
/Filip