### PR TITLE
export type instead of export

### DIFF
--- a/dist/VueMarkdown.d.ts
+++ b/dist/VueMarkdown.d.ts
@@ -1,4 +1,4 @@
 import { Component } from 'vue';
-export { Options } from 'markdown-it';
+export type { Options } from 'markdown-it';
 declare const VueMarkdown: Component;
 export default VueMarkdown;

--- a/src/VueMarkdown.ts
+++ b/src/VueMarkdown.ts
@@ -1,6 +1,6 @@
 import { h, PropType, VNode, Component, defineComponent } from 'vue'
 import MarkdownIt, { Options as MarkdownItOptions, PluginSimple } from 'markdown-it'
-export { Options } from 'markdown-it'
+export type { Options } from 'markdown-it'
 
 const VueMarkdown: Component = defineComponent({
   name: 'VueMarkdown',


### PR DESCRIPTION
Hi
I am trying to use Your library with isolatedModules in my tsconfig an this gives me an warning:

```
node_modules/vue-markdown-render/src/VueMarkdown.ts:3:10 - error TS1205: Re-exporting a type when 'isolatedModules' is enabled requires using 'export type'.

export { Options } from 'markdown-it'
              ~~~~~~~
```
i think it should be 
```
export type { Options } from 'markdown-it'
```
To provide more compatibility.